### PR TITLE
feat: reimplemented sidebar by reusing dialog's code instead of exten…

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -5,14 +5,18 @@
     <el-sidebar
       :visible.sync="showSidebar"
       title="Hello, Sidebar"
-      :show-title="false"
+      :hide-title="true"
+      :show-close="true"
+      position="right"
       padding="16px">
       <div>
         <h2>Sidebar content is here</h2>
       </div>
-      <span slot="footer">
+      <div
+        slot="footer"
+        style="padding: 20px">
         <el-button @click="showSidebar = false">Close</el-button>
-      </span>
+      </div>
     </el-sidebar>
   </div>
 </template>

--- a/src/index.vue
+++ b/src/index.vue
@@ -1,82 +1,232 @@
-<!--<template lang="pug">-->
-<!--</template>-->
+<template>
+  <transition
+    name="dialog-fade"
+    @after-enter="afterEnter"
+    @after-leave="afterLeave">
+    <div
+      class="el-dialog__wrapper"
+      v-show="visible"
+      @click.self="handleWrapperClick">
+      <div
+        role="dialog"
+        aria-modal="true"
+        :aria-label="title || 'dialog'"
+        class="el-dialog"
+        :class="[{'el-dialog--center': center }, customClass]"
+        ref="dialog"
+        :style="dialogStyle">
+        <div
+          class="el-dialog__header"
+          :style="headerStyle">
+          <slot name="title">
+            <span class="el-dialog__title">{{ title }}</span>
+          </slot>
+          <button
+            type="button"
+            class="el-dialog__headerbtn"
+            aria-label="Close"
+            v-if="showClose"
+            @click="handleClose">
+            <i class="el-dialog__close el-icon el-icon-close"/>
+          </button>
+        </div>
+        <div
+          class="el-dialog__body"
+          v-if="rendered"
+          :style="bodyStyle">
+          <slot/>
+        </div>
+        <div
+          class="el-dialog__footer"
+          v-if="$slots.footer">
+          <slot name="footer"/>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
 
 <script>
-import Dialog from 'element-ui/lib/dialog'
+import Popup from 'element-ui/src/utils/popup'
+import Migrating from 'element-ui/src/mixins/migrating'
+import emitter from 'element-ui/src/mixins/emitter'
 
-/**
- * This component extends the ElementUI Dialog component and positions it to the right side of the viewport as a
- * sidebar. Provides additional options, such as `showTitle` and `padding`
- */
 export default {
-  extends: Dialog,
+  name: 'ElDialog',
+  mixins: [Popup, emitter, Migrating],
   props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    modal: {
+      type: Boolean,
+      default: true
+    },
+    modalAppendToBody: {
+      type: Boolean,
+      default: true
+    },
+    appendToBody: {
+      type: Boolean,
+      default: false
+    },
+    lockScroll: {
+      type: Boolean,
+      default: true
+    },
+    closeOnClickModal: {
+      type: Boolean,
+      default: true
+    },
+    closeOnPressEscape: {
+      type: Boolean,
+      default: true
+    },
+    showClose: {
+      type: Boolean,
+      default: true
+    },
+    width: {
+      type: String,
+      default: '360px'
+    },
+    customClass: {
+      type: String,
+      default: ''
+    },
     top: {
       type: String,
       default: '0px'
     },
-    showTitle: {
+    bottom: {
+      type: String,
+      default: '0px'
+    },
+    beforeClose: {
+      type: Function,
+      default: undefined
+    },
+    center: {
       type: Boolean,
-      default: true
+      default: false
+    },
+    hideTitle: {
+      type: Boolean,
+      default: false
     },
     padding: {
       type: String,
       default: '0'
+    },
+    position: {
+      type: String,
+      default: 'right',
+      validator (v) {
+        // make sure it's either left or right
+        return ['left', 'right'].indexOf(v) > -1
+      }
     }
   },
-  mounted () {
-    // console.log('REF', this.$refs)
-
-    // initially call functions that watchers would call
-    this.updatePadding(this.padding)
-    this.setShowTitle(this.showTitle)
-  },
-  methods: {
-    /**
-     * Updates the padding of the dialog body
-     * @param {string} [p] - padding value
-     */
-    updatePadding (p) {
-      // wrap it in $nextTick as classList of child is not available on mounted() yet
-      this.$nextTick(() => {
-        // console.log('padding:', p)
-        // find dialog body and update its padding
-        for (const childNode of this.$refs.dialog.childNodes) {
-          // console.log(`padding checking ${childNode}'s classList: ${JSON.stringify(childNode.classList)}`)
-          if (childNode.classList && childNode.classList.contains('el-dialog__body')) {
-            childNode.style.padding = p
-            return
-          }
-        }
-        // console.warn('updatePadding: body was not updated! (DOM not ready?)')
-      })
-    },
-    /**
-     * Adds or removes a class to the dialog header that set's its display to `none`, depending on the provided boolean.
-     * @param {boolean} showTitle - whether to show the dialog title or not
-     */
-    setShowTitle (showTitle) {
-      if (showTitle) {
-        this.$refs.classList.remove('__hide_header')
-      } else {
-        this.$refs.classList.add('__hide_header')
-      }
+  data () {
+    return {
+      closed: false
     }
   },
   watch: {
-    showTitle (nVal) {
-      this.setShowTitle(nVal)
-    },
-    padding (nVal) {
-      this.updatePadding(nVal)
-    },
-    // we have to watch `visible`, as the body is lazy loaded. If the component is initialized with `visible=false`,
-    // the body is not rendered yet, so there is nothing to change the padding of
-    // watching visible ensures setting padding on first render
-    visible (isVisible) {
-      if (isVisible) {
-        this.updatePadding(this.padding)
+    visible (val) {
+      if (val) {
+        this.closed = false
+        this.$emit('open')
+        this.$el.addEventListener('scroll', this.updatePopper)
+        this.$nextTick(() => {
+          this.$refs.dialog.scrollTop = 0
+        })
+        if (this.appendToBody) {
+          document.body.appendChild(this.$el)
+        }
+      } else {
+        this.$el.removeEventListener('scroll', this.updatePopper)
+        if (!this.closed) this.$emit('close')
       }
+    }
+  },
+  computed: {
+    dialogStyle () {
+      let style = {
+        width: this.width,
+        marginTop: this.top,
+        marginBottom: this.bottom
+      }
+
+      // align on left or right viewport edge based on prop
+      if (this.position === 'left') {
+        style.left = 0
+      } else {
+        style.right = 0
+      }
+
+      return style
+    },
+    bodyStyle () {
+      return {
+        padding: this.padding
+      }
+    },
+    headerStyle () {
+      if (this.hideTitle) { return { display: 'none' } } else { return {} }
+    }
+  },
+  methods: {
+    getMigratingConfig () {
+      return {
+        props: {
+          'size': 'size is removed.'
+        }
+      }
+    },
+    handleWrapperClick () {
+      if (!this.closeOnClickModal) return
+      this.handleClose()
+    },
+    handleClose () {
+      if (typeof this.beforeClose === 'function') {
+        this.beforeClose(this.hide)
+      } else {
+        this.hide()
+      }
+    },
+    hide (cancel) {
+      if (cancel !== false) {
+        this.$emit('update:visible', false)
+        this.$emit('close')
+        this.closed = true
+      }
+    },
+    updatePopper () {
+      this.broadcast('ElSelectDropdown', 'updatePopper')
+      this.broadcast('ElDropdownMenu', 'updatePopper')
+    },
+    afterEnter () {
+      this.$emit('opened')
+    },
+    afterLeave () {
+      this.$emit('closed')
+    }
+  },
+  mounted () {
+    if (this.visible) {
+      this.rendered = true
+      this.open()
+      if (this.appendToBody) {
+        document.body.appendChild(this.$el)
+      }
+    }
+  },
+  destroyed () {
+    // if appendToBody is true, remove DOM node after destroy
+    if (this.appendToBody && this.$el && this.$el.parentNode) {
+      this.$el.parentNode.removeChild(this.$el)
     }
   }
 }
@@ -84,18 +234,11 @@ export default {
 
 <style scoped>
 .el-dialog {
-  margin-bottom: 0;
   position: fixed;
   top: 0;
   bottom: 0;
-  right: 0;
-  width: 360px;
   display: flex;
   flex-direction: column;
-}
-
-.__hide_header >>> .el-dialog__header {
-  display: none;
 }
 
 .el-dialog__header {
@@ -109,5 +252,6 @@ export default {
 
 .el-dialog__footer {
   flex: 0 0 auto;
+  padding: 0;
 }
 </style>

--- a/src/index.vue
+++ b/src/index.vue
@@ -52,7 +52,7 @@ import Migrating from 'element-ui/src/mixins/migrating'
 import emitter from 'element-ui/src/mixins/emitter'
 
 export default {
-  name: 'ElDialog',
+  name: 'ElSidebar',
   mixins: [Popup, emitter, Migrating],
   props: {
     title: {


### PR DESCRIPTION
…ding it

The sidebar has been reimplemented by copy-pasting dialog's original code and adapting/extending it.
Dialog's code coming from ElementUI commit 97728bddb52d9d2b6da6635d9dab3d71da4eeb48.

BREAKING CHANGE: `showTitle` prop has been inverted and is now named `hideTitle`. Title is still
visible by default.